### PR TITLE
Fixed ImageCropper crashes

### DIFF
--- a/client/src/screens/Camera/Camera.jsx
+++ b/client/src/screens/Camera/Camera.jsx
@@ -1,7 +1,7 @@
-import { Camera, CameraType, FlashMode } from "expo-camera"
+import { Camera, FlashMode } from "expo-camera"
 import * as ImagePicker from "expo-image-picker"
 import { useState, useEffect, useRef } from "react"
-import { Button, Text, TouchableOpacity, View, Image } from "react-native"
+import { Button, Text, TouchableOpacity, View, Image, Platform } from "react-native"
 import { useIsFocused } from "@react-navigation/native"
 import getAspectRatio from "../../utils/getAspectRatio.js"
 import findBestMatchingAspectRatio from "../../utils/findBestMatchingAspectRatio.js"
@@ -52,15 +52,16 @@ const CameraScreen = ({ navigation }) => {
   useEffect(() => {
     const setBestMatchingRatio = async () => {
       const aspectRatio = getAspectRatio()
-
-      if (cameraRef.current && isCameraReady) {
-        const supportedRatios =
-          await cameraRef.current.getSupportedRatiosAsync()
-        const bestRatio = findBestMatchingAspectRatio(
-          supportedRatios,
-          aspectRatio
-        )
-        setCameraRatio(bestRatio)
+      if (Platform.OS == 'android') {
+        if (cameraRef.current && isCameraReady) {
+          const supportedRatios =
+            await cameraRef.current.getSupportedRatiosAsync()
+          const bestRatio = findBestMatchingAspectRatio(
+            supportedRatios,
+            aspectRatio
+          )
+          setCameraRatio(bestRatio)
+        }
       }
     }
 

--- a/client/src/screens/Preview/Preview.jsx
+++ b/client/src/screens/Preview/Preview.jsx
@@ -13,8 +13,8 @@ import uploadImage from "../../utils/uploadImage"
 import confirmButton from "../../../assets/preview_ok_button.png"
 import returnButton from "../../../assets/preview_return_button.png"
 
-const window_width = Dimensions.get("window").width
-const window_height = Dimensions.get("window").height
+const window_width = Dimensions.get("screen").width
+const window_height = Dimensions.get("screen").height
 
 const startX = window_width / 2
 const startY = window_height / 2

--- a/client/src/utils/ImageCropper.js
+++ b/client/src/utils/ImageCropper.js
@@ -8,22 +8,36 @@ const ImageCropper = async ( photo, x, y, length ) => {
 
     // Image is captured at a higher quality than the screen allows.
     // To figure out the relative height and width, we must calculate the ratio between the two and multiply by it.
-    const { width, height } = Dimensions.get("window")              // Dimensions of the screen
+    const { width, height } = Dimensions.get("screen")              // Dimensions of the screen
     const imgHeight = image.height;                                 // Dimensions of the image
     const imgWidth = image.width;                       
 
     const ratioW = parseFloat((imgWidth / width).toFixed(5));       // Ratio of the Width
     const ratioH = parseFloat((imgHeight / height).toFixed(5));     // Ratio of the Height
-    //const avgRatio = (ratioH + ratioW) / 2                          // Average ratio to figure out the square length scaler
-    let relativeX = (x  - (length / 2)) * ratioW;
-    let relativeY = (y - (length / 2)) * ratioH - (Math.abs(height - imgHeight/ratioW))*2;
-    let relativeLength = length * ratioW;
-      
+    const avgRatio = (ratioH + ratioW) / 2                          // Average ratio to figure out the square length scaler
+    
+    // Compute relative coordinates on the image from the screen coordinates
+    let relativeX = (x  * ratioW)
+    let relativeY = (y * ratioH)
+    let relativeLength = length * avgRatio;
+    let relativeHeight = relativeLength
+    let relativeWidth = relativeLength
+    
+    relativeX = relativeX - (relativeLength / 2)
+    relativeY = relativeY - (relativeLength / 2)
+
+    // Check that the cropped area is within the image boundry
+    if (relativeY < 0) {relativeY = 0}
+    if (relativeX < 0) {relativeX = 0}
+    if (relativeX + relativeWidth > imgWidth) {relativeWidth = relativeWidth - ((relativeWidth + relativeX) - imgWidth)}
+    if (relativeY + relativeHeight > imgHeight) {relativeHeight = relativeHeight - ((relativeHeight + relativeY) - imgHeight)}
+
+
     // The actual cropping of the image
     const { uri: CropResult } = await manipulateAsync(
         image.uri,
         [
-            {crop: {height: relativeLength, originX: relativeX, originY: relativeY,  width: relativeLength}},
+            {crop: {originX: relativeX, originY: relativeY, height: relativeHeight, width: relativeWidth}},
             {resize: {height: 224, width: 224}}
         ],
         {base64: true}

--- a/client/src/utils/getAspectRatio.js
+++ b/client/src/utils/getAspectRatio.js
@@ -1,7 +1,7 @@
 import { Dimensions } from "react-native"
 
 const getAspectRatio = () => {
-  const { width, height } = Dimensions.get("window")
+  const { width, height } = Dimensions.get("screen")
   return height / width
 }
 


### PR DESCRIPTION
Fixed the crashes where the upscaled crop-region would be outside the bounds of the image.
Also added a check for android devices when applying the ratio fix.